### PR TITLE
Fix registration email to gmail

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -112,7 +112,9 @@ EMAIL_PORT = config('EMAIL_PORT', default=587, cast=int)
 EMAIL_USE_TLS = config('EMAIL_USE_TLS', default=True, cast=bool)
 EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
 EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
-DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default='noreply@restaurante-gyz.com')
+# Usar como remitente por defecto el usuario de Gmail si no se especifica otro
+DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default=config('EMAIL_HOST_USER', default=''))
+SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 # URLs para reset de contraseña
 LOGIN_URL = '/usuarios/login/'

--- a/usuarios/emails.py
+++ b/usuarios/emails.py
@@ -25,10 +25,11 @@ def enviar_correo_registro_exitoso(usuario):
         mensaje_texto = strip_tags(mensaje_html)
         
         # Enviar el correo
+        remitente = settings.EMAIL_HOST_USER or settings.DEFAULT_FROM_EMAIL
         send_mail(
             asunto,
             mensaje_texto,
-            settings.DEFAULT_FROM_EMAIL,
+            remitente,
             [usuario.email],
             html_message=mensaje_html,
             fail_silently=False,
@@ -69,10 +70,11 @@ def enviar_correo_recuperacion_password(usuario, request):
         mensaje_texto = strip_tags(mensaje_html)
         
         # Enviar el correo
+        remitente = settings.EMAIL_HOST_USER or settings.DEFAULT_FROM_EMAIL
         send_mail(
             asunto,
             mensaje_texto,
-            settings.DEFAULT_FROM_EMAIL,
+            remitente,
             [usuario.email],
             html_message=mensaje_html,
             fail_silently=False,
@@ -100,10 +102,11 @@ def enviar_correo_password_cambiado(usuario):
         mensaje_texto = strip_tags(mensaje_html)
         
         # Enviar el correo
+        remitente = settings.EMAIL_HOST_USER or settings.DEFAULT_FROM_EMAIL
         send_mail(
             asunto,
             mensaje_texto,
-            settings.DEFAULT_FROM_EMAIL,
+            remitente,
             [usuario.email],
             html_message=mensaje_html,
             fail_silently=False,

--- a/usuarios/forms.py
+++ b/usuarios/forms.py
@@ -78,6 +78,18 @@ class RegistroUsuarioForm(UserCreationForm):
         self.fields['password1'].help_text = 'Tu contraseña debe contener al menos 8 caracteres.'
         self.fields['password2'].help_text = 'Ingresa la misma contraseña que antes, para verificación.'
 
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        user.email = self.cleaned_data['email']
+        user.first_name = self.cleaned_data.get('first_name', '')
+        user.last_name = self.cleaned_data.get('last_name', '')
+        user.telefono = self.cleaned_data.get('telefono')
+        user.fecha_nacimiento = self.cleaned_data.get('fecha_nacimiento')
+        user.direccion = self.cleaned_data.get('direccion')
+        if commit:
+            user.save()
+        return user
+
 class LoginUsuarioForm(AuthenticationForm):
     """Formulario para login de usuarios"""
     


### PR DESCRIPTION
Enable email sending via Gmail upon user registration and ensure all user data is saved.

The previous email configuration was not correctly integrated with Gmail, preventing welcome emails from being sent. Additionally, the user registration form was not explicitly saving all custom user fields, which is now corrected to ensure data persistence and proper email triggering.

---
<a href="https://cursor.com/background-agent?bcId=bc-cdbf4a31-81a3-4ec6-be2f-a6d83ce33e78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cdbf4a31-81a3-4ec6-be2f-a6d83ce33e78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

